### PR TITLE
Parse mocha reporter options only if there are any to parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,9 @@ function Reporter(runner, mochaOptions) {
   this.options = {};
 
   this.options = parseEnvOptions(this.options);
-  this.options = parseMochaReporterOptions(this.options, mochaOptions.reporterOptions);
+  
+  if (mochaOptions.reporterOptions) 
+    this.options = parseMochaReporterOptions(this.options, mochaOptions.reporterOptions);
 
   var stats = this.stats = {suites: 0, tests: 0, passes: 0, pending: 0, failures: 0, timeouts: 0};
   var failures = this.failures = [];


### PR DESCRIPTION
Without this, I currently get this error:

```
  if('hide-titles' in reporterOptions)
                      ^
TypeError: Cannot use 'in' operator to search for 'hide-titles' in undefined
```
